### PR TITLE
Toggle / Remove actions from tree visualization

### DIFF
--- a/shells/dev/src/devtools.js
+++ b/shells/dev/src/devtools.js
@@ -15,7 +15,6 @@ target.onload = () => {
         targetWindow.parent.addEventListener('message', evt => fn(evt.data))
       },
       send(data) {
-        console.log('sending data')
         console.log('devtools -> backend', data)
         targetWindow.postMessage(data, '*')
       }

--- a/src/backend/history.js
+++ b/src/backend/history.js
@@ -4,10 +4,12 @@ export function trackHistory(hook, bridge) {
 
   history.on('append', action => {
     bridge.on(`toggle:${action.id}`, () => history.toggle(action))
+    bridge.on(`remove:${action.id}`, () => history.remove(action))
   })
 
   history.on('remove', action => {
     bridge.removeAllListeners(`toggle:${action.id}`)
+    bridge.removeAllListeners(`remove:${action.id}`)
   })
 
   history.on('reconcile', function() {

--- a/src/backend/history.js
+++ b/src/backend/history.js
@@ -5,11 +5,13 @@ export function trackHistory(hook, bridge) {
   history.on('append', action => {
     bridge.on(`toggle:${action.id}`, () => history.toggle(action))
     bridge.on(`remove:${action.id}`, () => history.remove(action))
+    bridge.on(`checkout:${action.id}`, () => history.checkout(action))
   })
 
   history.on('remove', action => {
     bridge.removeAllListeners(`toggle:${action.id}`)
     bridge.removeAllListeners(`remove:${action.id}`)
+    bridge.removeAllListeners(`checkoute:${action.id}`)
   })
 
   history.on('reconcile', function() {

--- a/src/backend/history.js
+++ b/src/backend/history.js
@@ -1,11 +1,23 @@
 export function trackHistory(hook, bridge) {
   const repo = hook.repo
+  const history = repo.history
 
-  repo.history.on('reconcile', function() {
-    bridge.send('history:reconcile', JSON.stringify(repo.history))
+  history.on('append', action => {
+    bridge.on(`toggle:${action.id}`, () => history.toggle(action))
   })
 
-  repo.history.on('release', function() {
+  history.on('remove', action => {
+    bridge.removeAllListeners(`toggle:${action.id}`)
+  })
+
+  history.on('reconcile', function() {
+    bridge.send('history:reconcile', JSON.stringify(history))
+  })
+
+  history.on('release', function() {
     bridge.send('history:release', JSON.stringify(repo.state))
   })
+
+  // Force a reconciliation
+  history.checkout()
 }

--- a/src/devtools/effects/events.js
+++ b/src/devtools/effects/events.js
@@ -33,10 +33,16 @@ class Events {
     this.bridge.send(`remove:${id}`)
   }
 
+  checkout(repo, id) {
+    console.log('sending checkout:', id)
+    this.bridge.send(`checkout:${id}`)
+  }
+
   register() {
     return {
       ['toggle']: this.toggle,
-      ['remove']: this.remove
+      ['remove']: this.remove,
+      ['checkout']: this.checkout
     }
   }
 }

--- a/src/devtools/effects/events.js
+++ b/src/devtools/effects/events.js
@@ -24,6 +24,16 @@ class Events {
   teardown() {
     this.bridge.removeAllListeners()
   }
+
+  toggle(repo, id) {
+    this.bridge.send(`toggle:${id}`)
+  }
+
+  register() {
+    return {
+      ['toggle']: this.toggle
+    }
+  }
 }
 
 export default Events

--- a/src/devtools/effects/events.js
+++ b/src/devtools/effects/events.js
@@ -29,9 +29,14 @@ class Events {
     this.bridge.send(`toggle:${id}`)
   }
 
+  remove(repo, id) {
+    this.bridge.send(`remove:${id}`)
+  }
+
   register() {
     return {
-      ['toggle']: this.toggle
+      ['toggle']: this.toggle,
+      ['remove']: this.remove
     }
   }
 }

--- a/src/devtools/views/tree/node.js
+++ b/src/devtools/views/tree/node.js
@@ -42,6 +42,10 @@ function Node({ action, x, y, send }) {
       <text y="-20" onClick={() => send('remove', action.id)}>
         Remove
       </text>
+
+      <text y="-35" onClick={() => send('checkout', action.id)}>
+        Checkout
+      </text>
     </g>
   )
 }

--- a/src/devtools/views/tree/node.js
+++ b/src/devtools/views/tree/node.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import withSend from 'microcosm/addons/with-send'
 
 function fill({ status }) {
   switch (status) {
@@ -17,14 +18,25 @@ function fill({ status }) {
   }
 }
 
-export default function Node({ action, x, y }) {
+function Node({ action, x, y, send }) {
   return (
     <g transform={`translate(${x},${y})`}>
       <circle r="10" opacity="0" />
       <circle r="3" fill={fill(action)} />
 
-      <text y="5" x="8" fontSize="11" textAnchor="start" fill="white" transform="rotate(45)">
+      <text
+        y="5"
+        x="8"
+        fontSize="12"
+        textAnchor="start"
+        fill={action.disabled ? 'gray' : 'white'}
+        transform="rotate(45)"
+      >
         {action.type}
+      </text>
+
+      <text y="-5" onClick={() => send('toggle', action.id)}>
+        Toggle
       </text>
     </g>
   )
@@ -34,3 +46,5 @@ Node.defaultProps = {
   x: 0,
   y: 0
 }
+
+export default withSend(Node)

--- a/src/devtools/views/tree/node.js
+++ b/src/devtools/views/tree/node.js
@@ -38,6 +38,10 @@ function Node({ action, x, y, send }) {
       <text y="-5" onClick={() => send('toggle', action.id)}>
         Toggle
       </text>
+
+      <text y="-20" onClick={() => send('remove', action.id)}>
+        Remove
+      </text>
     </g>
   )
 }


### PR DESCRIPTION
![toggle-remove](https://cloud.githubusercontent.com/assets/1410181/26473559/6b1c362c-4169-11e7-8c41-ca4077e333b7.gif)

When an action is appended to history, set up a listener over the bridges to `toggle:[id]` and `remove:[id]` which trigger the respective actions in history. Remove all listeners if an action is removed from history.

[edit]
Added checkout as well:
![checkout](https://cloud.githubusercontent.com/assets/1410181/26473831/c8f88c4a-416a-11e7-8cf9-079496ea0168.gif)
