### PR TITLE
Reboot bridge on page refresh

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     "sort-vars": 2,
     "comma-dangle": [2, "never"],
     "no-console": 0,
+    "no-debugger": 1,
     "no-unused-vars" : [2, { "args": "none" }],
     "react/jsx-equals-spacing": ["warn", "never"],
     "react/jsx-no-duplicate-props": ["warn", { "ignoreCase": true }],

--- a/shells/chrome/src/devtools.js
+++ b/shells/chrome/src/devtools.js
@@ -2,8 +2,8 @@
  * @fileoverview This script is called when the dev tools panel is activated.
  */
 
-import { initDevTools } from 'src/devtools'
-import Bridge from 'src/bridge'
+import { initDevTools } from '../../../src/devtools'
+import Bridge from '../../../src/bridge'
 
 initDevTools({
   connect(callback) {
@@ -34,10 +34,10 @@ initDevTools({
       // 4. wire up devTools-to-window bridge
       callback(bridge)
     })
-  },
 
-  onReload(callback) {
-    chrome.devtools.network.onNavigated.addListener(callback)
+    chrome.devtools.network.onNavigated.addListener(() =>
+      this.connect(callback)
+    )
   }
 })
 

--- a/shells/chrome/webpack.config.js
+++ b/shells/chrome/webpack.config.js
@@ -40,8 +40,7 @@ module.exports = {
           {
             loader: 'babel-loader',
             options: {
-              cacheDirectory: '.babel-cache',
-              plugins: ['react-hot-loader/babel']
+              cacheDirectory: true
             }
           }
         ]

--- a/shells/dev/src/devtools.js
+++ b/shells/dev/src/devtools.js
@@ -17,7 +17,6 @@ target.onload = () => {
             targetWindow.parent.addEventListener('message', evt => fn(evt.data))
           },
           send(data) {
-            console.log('devtools -> backend', data)
             targetWindow.postMessage(data, '*')
           }
         })
@@ -25,9 +24,6 @@ target.onload = () => {
         // 4. wire up devTools-to-window bridge
         callback(devToolsBridge)
       })
-    },
-    onReload(callback) {
-      target.onload = callback
     }
   })
 }

--- a/shells/dev/target/index.js
+++ b/shells/dev/target/index.js
@@ -2,8 +2,7 @@ import boot from './boot'
 
 let repo = boot('#app')
 
-repo.seed()
-
 let hook = window.__MICROCOSM_DEVTOOLS_GLOBAL_HOOK__
-
 hook.emit('init', repo)
+
+repo.seed()

--- a/shells/dev/target/index.js
+++ b/shells/dev/target/index.js
@@ -2,6 +2,8 @@ import boot from './boot'
 
 let repo = boot('#app')
 
+repo.seed()
+
 let hook = window.__MICROCOSM_DEVTOOLS_GLOBAL_HOOK__
 
 hook.emit('init', repo)

--- a/shells/dev/webpack.config.js
+++ b/shells/dev/webpack.config.js
@@ -1,14 +1,9 @@
 var FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin')
 var alias = require('../alias')
-var webpack = require('webpack')
 
 module.exports = {
   entry: {
-    devtools: [
-      'react-hot-loader/patch',
-      'react-dev-utils/webpackHotDevClient',
-      './src/devtools.js'
-    ],
+    devtools: ['./src/devtools.js'],
     backend: './src/backend.js',
     hook: './src/hook.js',
     target: './target/index.js'
@@ -43,8 +38,7 @@ module.exports = {
           {
             loader: 'babel-loader',
             options: {
-              cacheDirectory: '.babel-cache',
-              plugins: ['react-hot-loader/babel']
+              cacheDirectory: true
             }
           }
         ]
@@ -81,12 +75,7 @@ module.exports = {
   },
   devtool: '#cheap-eval-source-map',
   devServer: {
-    hot: true,
     quiet: true
   },
-  plugins: [
-    new FriendlyErrorsPlugin(),
-    new webpack.HotModuleReplacementPlugin(),
-    new webpack.NamedModulesPlugin()
-  ]
+  plugins: [new FriendlyErrorsPlugin()]
 }

--- a/src/backend/history.js
+++ b/src/backend/history.js
@@ -49,6 +49,6 @@ export function trackHistory(hook, bridge) {
     bridge.send('history:release', JSON.stringify(repo.state))
   })
 
-  // Run some seed data
-  repo.seed()
+  // Force a change to trigger the process
+  repo.checkout()
 }

--- a/src/devtools/index.js
+++ b/src/devtools/index.js
@@ -11,8 +11,6 @@ export function initDevTools(shell) {
     window.bridge = bridge
     initApp()
   })
-
-  shell.onReload(initApp)
 }
 
 export function initApp() {

--- a/src/devtools/views/snapshot/snapshot.css
+++ b/src/devtools/views/snapshot/snapshot.css
@@ -1,6 +1,7 @@
 .container {
   background: linear-gradient(#ffffff 70%, #f9f9f9 100%);
   height: 100%;
+  overflow: auto;
 }
 
 .header {


### PR DESCRIPTION
Figured out it! When the page reloads, we need to reconnect the event bridge. This also causes a full re-render of the debugger. Maybe in a later pass we could figure out how to change that, like maybe push an action to update the bridge.

![refresh](https://user-images.githubusercontent.com/590904/27586707-70956b68-5b0f-11e7-80c7-1a5a56506fe4.gif)
