### PR TITLE
Subscribe to existing actions in history tracking

### DIFF
--- a/src/backend/history.js
+++ b/src/backend/history.js
@@ -2,7 +2,7 @@ export function trackHistory(hook, bridge) {
   const repo = hook.repo
   const history = repo.history
 
-  history.toArray().forEach(function (action) {
+  history.toArray().forEach(function(action) {
     registerAction(bridge, repo, action)
   })
 
@@ -10,7 +10,7 @@ export function trackHistory(hook, bridge) {
     registerAction(bridge, repo, action)
   })
 
-  history.on('remove', function (action) {
+  history.on('remove', function(action) {
     deregisterAction(bridge, action)
   })
 

--- a/src/backend/history.js
+++ b/src/backend/history.js
@@ -2,53 +2,69 @@ export function trackHistory(hook, bridge) {
   const repo = hook.repo
   const history = repo.history
 
-  history.on('append', action => {
-    bridge.on(`toggle:${action.id}`, () => {
-      history.toggle(action)
-      // if toggling an inactive action, history won't reconcile
-      // we still want to know what history looks like though
-      bridge.send('history:reconcile', JSON.stringify(history))
-    })
-
-    bridge.on(`remove:${action.id}`, () => {
-      history.remove(action)
-      bridge.send('history:reconcile', JSON.stringify(history))
-    })
-
-    bridge.on(`checkout:${action.id}`, () => history.checkout(action))
-
-    bridge.on('revert', () => {
-      history.root.children = []
-      history.checkout(history.root)
-    })
-
-    bridge.on('commit', () => {
-      action = history.append('commit', 'resolve')
-      history.root = action
-
-      history.checkout(action)
-    })
-
-    bridge.on(`detail:${action.id}`, () => {
-      bridge.send('snapshot', JSON.stringify(repo.archive.get(action)))
-    })
+  history.toArray().forEach(function (action) {
+    registerAction(bridge, repo, action)
   })
 
-  history.on('remove', action => {
-    bridge.removeAllListeners(`toggle:${action.id}`)
-    bridge.removeAllListeners(`remove:${action.id}`)
-    bridge.removeAllListeners(`checkout:${action.id}`)
-    bridge.removeAllListeners(`detail:${action.id}`)
+  history.on('append', function(action) {
+    registerAction(bridge, repo, action)
+  })
+
+  history.on('remove', function (action) {
+    deregisterAction(bridge, action)
   })
 
   history.on('reconcile', function() {
-    bridge.send('history:reconcile', JSON.stringify(history))
+    bridge.send('history:reconcile', history)
   })
 
   history.on('release', function() {
-    bridge.send('history:release', JSON.stringify(repo.state))
+    bridge.send('history:release', repo.state)
   })
 
   // Force a change to trigger the process
   repo.checkout()
+}
+
+function registerAction(bridge, repo, action) {
+  const history = repo.history
+
+  deregisterAction(bridge, action)
+
+  bridge.on(`toggle:${action.id}`, () => {
+    history.toggle(action)
+    // if toggling an inactive action, history won't reconcile
+    // we still want to know what history looks like though
+    bridge.send('history:reconcile', history)
+  })
+
+  bridge.on(`remove:${action.id}`, () => {
+    history.remove(action)
+    bridge.send('history:reconcile', history)
+  })
+
+  bridge.on(`checkout:${action.id}`, () => history.checkout(action))
+
+  bridge.on('revert', () => {
+    history.root.children = []
+    history.checkout(history.root)
+  })
+
+  bridge.on('commit', () => {
+    action = history.append('commit', 'resolve')
+    history.root = action
+
+    history.checkout(action)
+  })
+
+  bridge.on(`detail:${action.id}`, () => {
+    bridge.send('snapshot', repo.archive.get(action))
+  })
+}
+
+function deregisterAction(bridge, action) {
+  bridge.removeAllListeners(`toggle:${action.id}`)
+  bridge.removeAllListeners(`remove:${action.id}`)
+  bridge.removeAllListeners(`checkout:${action.id}`)
+  bridge.removeAllListeners(`detail:${action.id}`)
 }

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -17,10 +17,7 @@ export default class Bridge extends EventEmitter {
   }
 
   send(event, payload) {
-    this.wall.send({
-      event,
-      payload
-    })
+    this.wall.send({ event, payload: JSON.stringify(payload) })
   }
 
   log(message) {


### PR DESCRIPTION
This commit fixes an issue where event subscription is never setup for actions that are already inside of a Microcosm. When the history tracker is installed, it loops through all existing actions and installs the same subscriptions as when they are appended.

![old-actions](https://user-images.githubusercontent.com/590904/27686105-47811a60-5c9f-11e7-8d38-6e67f866a849.gif)
